### PR TITLE
Add an http2 required ciphersuite for raft server

### DIFF
--- a/kronosutil/certs.go
+++ b/kronosutil/certs.go
@@ -29,6 +29,7 @@ const (
 var tls12CipherSuitesDefaultValue = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, // required for http servers
 }
 
 // SSLCreds returns credentials by reading keys and certificates from
@@ -134,6 +135,12 @@ func convertTLSVersionStrToInt(tlsVersionStr string) (uint16, error) {
 
 func GetTLSVersions() (uint16, uint16) {
 	minVersion := os.Getenv(defaultMinTLSVersionKey)
+	if minVersion == "" {
+		log.Infof(
+			context.Background(),
+			"TLS versions not provided. Using default values.")
+		return defaultMinTLSVersionValue, defaultMaxTLSVersionValue
+	}
 	minVersionInt, err := convertTLSVersionStrToInt(minVersion)
 	if err != nil {
 		log.Errorf(
@@ -143,6 +150,12 @@ func GetTLSVersions() (uint16, uint16) {
 		return defaultMinTLSVersionValue, defaultMaxTLSVersionValue
 	}
 	maxVersion := os.Getenv(defaultMaxTLSVersionKey)
+	if maxVersion == "" {
+		log.Infof(
+			context.Background(),
+			"TLS versions not provided. Using default values.")
+		return defaultMinTLSVersionValue, defaultMaxTLSVersionValue
+	}
 	maxVersionInt, err := convertTLSVersionStrToInt(maxVersion)
 	if err != nil {
 		log.Errorf(
@@ -168,6 +181,12 @@ func GetTLSVersions() (uint16, uint16) {
 
 func GetTls12CipherSuites() []uint16 {
 	ianaTls12Ciphers := os.Getenv(defaultTLS12CipherSuitesKey)
+	if ianaTls12Ciphers == "" {
+		log.Infof(
+			context.Background(),
+			"TLS 1.2 cipher suites not provided. Using default values.")
+		return tls12CipherSuitesDefaultValue
+	}
 	convertedCiphers, err := parseTLS12CipherSuites(ianaTls12Ciphers)
 	if err != nil {
 		log.Errorf(


### PR DESCRIPTION
Summary:
The RAFT server on port 5766 needs either
TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 or
TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 in
the list of cipher suites in the config. Not
including one of those cipher suites would
prevent the server from starting with an error
like this:

```
2024-07-22T00:45:02.219	INFO	78	1@runtime/asm_amd64.s:1594	the server is terminating due to a fatal error (see the KRONOS channel for details)
2024-07-22T00:45:02.219	FATAL	78	13@runtime/asm_amd64.s:1594	Failed to serve rafthttp (‹http2: TLSConfig.CipherSuites is missing an HTTP/2-required AES_128_GCM_SHA256 cipher (need at least one of TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 or TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)›)goroutine 78 [running]:
runtime/debug.Stack()
	GOROOT/src/runtime/debug/stack.go:24 +0x65
github.com/cockroachdb/cockroach/pkg/util/log.(*loggerT).outputLogEntry(0xc00006cc00, {{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}}, 0x17e4625b63df8148, ...})
	github.com/cockroachdb/cockroach/pkg/util/log/clog.go:261 +0xb8
github.com/cockroachdb/cockroach/pkg/util/log.logfDepthInternal({0x641aff8, 0xc000128000}, 0x4, 0x4, 0xd, 0x0?, {0x555afe6, 0x1d}, {0xc00077a490, 0x1, ...})
	github.com/cockroachdb/cockroach/pkg/util/log/channels.go:106 +0x645
github.com/cockroachdb/cockroach/pkg/util/log.logfDepth(...)
	github.com/cockroachdb/cockroach/pkg/util/log/channels.go:39
github.com/cockroachdb/cockroach/pkg/util/log.loggerKronos.FatalfDepth(...)
	github.com/cockroachdb/cockroach/bazel-out/k8-fastbuild/bin/pkg/util/log/log_channels_generated.go:6386
github.com/rubrikinc/kronos/kronosutil/log.Fatalf(...)
	github.com/rubrikinc/kronos/kronosutil/log/external/com_github_rubrikinc_kronos/kronosutil/log/log.go:108
github.com/rubrikinc/kronos/oracle.(*raftNode).serveRaft(0xc001c4a2c0, {0x641aff8, 0xc000128000}, 0xc002721260, 0xc0009987b0)
	github.com/rubrikinc/kronos/oracle/external/com_github_rubrikinc_kronos/oracle/raft.go:1245 +0x6af
created by github.com/rubrikinc/kronos/oracle.(*raftNode).startRaft
	github.com/rubrikinc/kronos/oracle/external/com_github_rubrikinc_kronos/oracle/raft.go:984 +0x152a
```

This diff ensures that one of those values
is always added to the cipher suites list
before starting the server.

Test Plan: Manual test

Reviewers: grammar-police!, Sir.Alfred

JIRA Issues: CDM-437246

Differential Revision: https://phabricator.rubrik.com/D332775