### PR TITLE
Update certs_test.go default cipher suites test

### DIFF
--- a/kronosutil/certs_test.go
+++ b/kronosutil/certs_test.go
@@ -34,6 +34,7 @@ func TestGetTls12CipherSuites(t *testing.T) {
 			expectedCipherSuites: []uint16{
 				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			},
 		},
 	}


### PR DESCRIPTION
I added TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256  to the default cipher suites in this commit https://github.com/rubrikinc/kronos/commit/9104d65052d7a8fd7f3162b5d2c6d5e9c6803675 but didn’t update the UT that checks the default value. This PR fixes that.