### PR TITLE
Fix nil pointer crash when stale raft entries exist in cluster

### DIFF
--- a/oracle/raft.go
+++ b/oracle/raft.go
@@ -349,6 +349,21 @@ func (rc *raftNode) addNode(id string, addr *kronospb.NodeAddr) error {
 	return nil
 }
 
+// getNodeDescForConfState looks up gossip info for a node that's in the raft
+// conf state. Returns an error if no gossip info is found, which typically
+// indicates a stale or duplicate entry in the Kronos cluster metadata.
+func getNodeDescForConfState(g *gossip.Server, nodeID string) (*kronospb.NodeDescriptor, error) {
+	nodeDesc := g.GetNodeDesc(nodeID)
+	if nodeDesc == nil {
+		return nil, fmt.Errorf(
+			"no gossip info found for node %s present in raft conf state. "+
+				"This likely indicates a stale/duplicate entry in the Kronos cluster. "+
+				"Run 'cockroach kronos cluster remove %s' from a healthy node to fix this",
+			nodeID, nodeID)
+	}
+	return nodeDesc, nil
+}
+
 // updateClusterFromConfState updates the cluster metadata and raft peers with
 // the nodes present in the confstate. It fetches the current cluster metadata
 // from raft leader and other nodes to get the metadata for the nodes which could've
@@ -387,7 +402,10 @@ func (rc *raftNode) updateClusterFromConfState(ctx context.Context, snapshotInde
 	rc.gossip.WaitForNRoundsofGossip(time.Minute, 2)
 	added := 0
 	for nodeID := range nodesToAdd {
-		nodeDesc := rc.gossip.GetNodeDesc(nodeID)
+		nodeDesc, err := getNodeDescForConfState(rc.gossip, nodeID)
+		if err != nil {
+			log.Fatalf(ctx, "%v", err)
+		}
 		addr, err := getNodeAddr(nodeDesc.RaftAddr)
 		if err != nil {
 			log.Errorf(ctx, "Failed to get node addr for node %s, err: %v", nodeID, err)

--- a/oracle/raft_test.go
+++ b/oracle/raft_test.go
@@ -11,8 +11,10 @@ import (
 	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 
+	"github.com/rubrikinc/kronos/gossip"
 	"github.com/rubrikinc/kronos/metadata"
 	"github.com/rubrikinc/kronos/pb"
+	"github.com/rubrikinc/kronos/protoutil"
 )
 
 func TestWithProtocol(t *testing.T) {
@@ -406,4 +408,46 @@ func TestSanitizeOutgoingMessages(t *testing.T) {
 			assert.Equal(t, tc.ExpectedMessages, outputMessages)
 		})
 	}
+}
+
+func addNodeDescToGossip(t *testing.T, g *gossip.Server, nodeID, grpcAddr, raftAddr string) {
+	t.Helper()
+	desc := &kronospb.NodeDescriptor{
+		NodeId:   nodeID,
+		GrpcAddr: grpcAddr,
+		RaftAddr: raftAddr,
+	}
+	data, err := protoutil.Marshal(desc)
+	assert.NoError(t, err)
+	g.SetInfo(gossip.NodeDescriptorPrefix.Encode(nodeID), data)
+}
+
+func TestGetNodeDescForConfState(t *testing.T) {
+	a := assert.New(t)
+
+	// Create a gossip server with a different node ID so that SetInfo
+	// callbacks don't skip our test nodes (addPeerLocked skips self).
+	g := gossip.NewServer("", nil, nil, "")
+	g.SetNodeID(context.Background(), "self-node")
+
+	// Populate gossip with valid node descriptors, simulating a real cluster.
+	addNodeDescToGossip(t, g, "ab72bb2588db743e", "10.100.205.10:5766", "https://10.100.205.10:5767")
+	addNodeDescToGossip(t, g, "d5da1f8fecbf0671", "10.100.205.11:5766", "https://10.100.205.11:5767")
+
+	// Valid node: should return descriptor without error.
+	desc, err := getNodeDescForConfState(g, "ab72bb2588db743e")
+	a.NoError(err)
+	a.NotNil(desc)
+	a.Equal("ab72bb2588db743e", desc.NodeId)
+	a.Equal("https://10.100.205.10:5767", desc.RaftAddr)
+
+	// Stale/duplicate raft ID with no gossip info: should return error
+	// with the raft ID and remediation instructions.
+	staleID := "1a97b5675026a901"
+	desc, err = getNodeDescForConfState(g, staleID)
+	a.Nil(desc)
+	a.Error(err)
+	a.Contains(err.Error(), staleID)
+	a.Contains(err.Error(), "cockroach kronos cluster remove "+staleID)
+	a.Contains(err.Error(), "stale/duplicate")
 }


### PR DESCRIPTION
## Summary

When a node joins a Kronos cluster that has duplicate/stale
raft entries (e.g., from a manually wiped kronos directory
without removing the old raft ID),
`updateClusterFromConfState` crashes with a nil pointer
dereference (SIGSEGV) because `GetNodeDesc` returns nil for
the stale raft ID.

This replaces the opaque SIGSEGV with an actionable fatal
error message that includes the stale raft ID and the exact
`cockroach kronos cluster remove` command to run.

Consistent with the existing `checkDuplicate` pattern which
uses `log.Fatalf` for the same class of problem.

## Test plan

- [x] Added `TestGetNodeDescForConfState` — populates a
      gossip server with valid nodes and verifies that a
      stale raft ID (with no gossip entry) produces the
      correct error with remediation instructions
- [x] All existing oracle tests pass
      (`go test -v ./oracle/`)
- [x] Build passes (`go build ./...`)

Fixes: CDM-528605