### PR TITLE
Serve OracleSM.State from an atomic pointer to drop the hot-path clone

### DIFF
--- a/oracle/state_machine.go
+++ b/oracle/state_machine.go
@@ -8,7 +8,9 @@ import (
 
 // StateMachine is used for managing current oracle and time cap
 type StateMachine interface {
-	// State returns a snapshot of the current state of the state machine.
+	// State returns an immutable snapshot of the current state of the state
+	// machine. Implementations may share the returned pointer across calls,
+	// so callers must not mutate the returned proto.
 	State(ctx context.Context) *kronospb.OracleState
 	// SubmitProposal submits a proposal to update the StateMachine.
 	// This function does not return anything as the proposal is async, it may get

--- a/oracle/state_machine_mem.go
+++ b/oracle/state_machine_mem.go
@@ -2,27 +2,31 @@ package oracle
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/rubrikinc/kronos/kronosutil/log"
 	"github.com/rubrikinc/kronos/pb"
-	"github.com/rubrikinc/kronos/protoutil"
 	"github.com/rubrikinc/kronos/syncutil"
 )
 
-// inMemStateMachine is an in-memory implementation of StateMachine
+// inMemStateMachine is an in-memory implementation of StateMachine.
+//
+// state is published atomically so State() can return a shared pointer
+// without locking or cloning. Writers serialize on the embedded RWMutex to
+// protect the compare-then-swap validation, but always publish a fresh
+// *OracleState via state.Store — the pointee is never mutated in place.
+// Callers of State() must treat the returned proto as immutable.
 type inMemStateMachine struct {
 	syncutil.RWMutex
-	state *kronospb.OracleState
+	state atomic.Pointer[kronospb.OracleState]
 }
 
 var _ StateMachine = &inMemStateMachine{}
 
-// State returns a snapshot of the current state of the state machine
+// State returns an immutable snapshot of the current state of the state
+// machine. The returned proto must not be mutated by the caller.
 func (s *inMemStateMachine) State(ctx context.Context) *kronospb.OracleState {
-	s.RLock()
-	defer s.RUnlock()
-	v := protoutil.Clone(s.state)
-	return v.(*kronospb.OracleState)
+	return s.state.Load()
 }
 
 // SubmitProposal submits a new proposal to the StateMachine. The state machine
@@ -31,11 +35,12 @@ func (s *inMemStateMachine) State(ctx context.Context) *kronospb.OracleState {
 func (s *inMemStateMachine) SubmitProposal(ctx context.Context, proposal *kronospb.OracleProposal) {
 	s.Lock()
 	defer s.Unlock()
+	cur := s.state.Load()
 	if proposal.ProposedState == nil {
 		log.Warningf(
 			ctx,
 			"Ignoring unexpected proposal: proposed state is nil, current state: %v, proposal: %v",
-			s.state, proposal,
+			cur, proposal,
 		)
 		return
 	}
@@ -48,39 +53,40 @@ func (s *inMemStateMachine) SubmitProposal(ctx context.Context, proposal *kronos
 	// better off enforcing by matching uuids. But in our application, proposers
 	// are not adversarial, and they always set the next ID to one more than what
 	// they see.
-	if newState.Id != s.state.Id+1 {
+	if newState.Id != cur.Id+1 {
 		log.Infof(
 			ctx,
 			"Proposal rejected because it does not sequence immediately after the current ID,"+
 				" current state: %v, proposal: %v",
-			s.state, proposal,
+			cur, proposal,
 		)
 		return
 	}
 	// Ensure monotonicity
-	if newState.TimeCap <= s.state.TimeCap {
+	if newState.TimeCap <= cur.TimeCap {
 		log.Infof(
 			ctx,
 			"Proposal rejected because the proposed time cap is not more than the current time cap,"+
 				" current state: %v, proposal: %v",
-			s.state, proposal,
+			cur, proposal,
 		)
 		return
 	}
-	s.state = &kronospb.OracleState{
+	s.state.Store(&kronospb.OracleState{
 		Oracle:          newState.Oracle,
 		TimeCap:         newState.TimeCap,
 		Id:              newState.Id,
 		KronosUptimeCap: newState.KronosUptimeCap,
-	}
+	})
 }
 
 // restoreState restores the StateMachine to the given state
 func (s *inMemStateMachine) restoreState(state kronospb.OracleState) {
 	s.Lock()
 	defer s.Unlock()
-	if s.state == nil || state.Id > s.state.Id {
-		s.state = &state
+	cur := s.state.Load()
+	if cur == nil || state.Id > cur.Id {
+		s.state.Store(&state)
 	}
 }
 
@@ -91,6 +97,6 @@ func (s *inMemStateMachine) Close() {}
 // NewMemStateMachine returns an instance of in memory oracle state machine
 func NewMemStateMachine() StateMachine {
 	memStateMachine := &inMemStateMachine{}
-	memStateMachine.state = &kronospb.OracleState{}
+	memStateMachine.state.Store(&kronospb.OracleState{})
 	return memStateMachine
 }

--- a/oracle/state_machine_mem_test.go
+++ b/oracle/state_machine_mem_test.go
@@ -211,7 +211,7 @@ func TestSubmitProposal(t *testing.T) {
 			stateMachine := NewMemStateMachine().(*inMemStateMachine)
 			defer stateMachine.Close()
 			if tc.state != nil {
-				stateMachine.state = tc.state
+				stateMachine.state.Store(tc.state)
 			}
 			initialState := protoutil.Clone(stateMachine.State(ctx))
 			stateMachine.SubmitProposal(ctx, tc.proposal)
@@ -300,7 +300,7 @@ func TestProposeState(t *testing.T) {
 			stateMachine := NewMemStateMachine().(*inMemStateMachine)
 			defer stateMachine.Close()
 			if tc.state != nil {
-				stateMachine.state = tc.state
+				stateMachine.state.Store(tc.state)
 			}
 			initialState := protoutil.Clone(stateMachine.State(ctx))
 			stateMachine.restoreState(*tc.proposedState)
@@ -311,4 +311,26 @@ func TestProposeState(t *testing.T) {
 			}
 		})
 	}
+}
+
+// BenchmarkStateReadParallel exercises the hot read path from
+// Server.KronosTimeNow (CDM-552295): every CockroachDB HLC clock read calls
+// OracleSM.State(ctx). The benchmark should report 0 allocs/op — a regression
+// to non-zero means someone reintroduced a deep copy on the read path.
+func BenchmarkStateReadParallel(b *testing.B) {
+	ctx := context.Background()
+	sm := NewMemStateMachine().(*inMemStateMachine)
+	sm.state.Store(&kronospb.OracleState{
+		Id:              1,
+		TimeCap:         1_000_000,
+		KronosUptimeCap: 500_000,
+		Oracle:          &kronospb.NodeAddr{Host: "127.0.0.1", Port: "5766"},
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = sm.State(ctx)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
Every CockroachDB HLC clock read hits Server.KronosTimeNow, which starts by calling k.OracleSM.State(ctx). The in-memory state machine implemented that as a gogo/proto.Clone of the whole OracleState under RLock, so every reader paid a reflection-based deep copy and readers still serialized on the clone.

Publish *OracleState via atomic.Pointer instead. Writers already allocated a fresh proto on every accepted proposal and on restore, so switching to Store is a pointer-swap change with no in-place mutation. State() becomes s.state.Load() — no lock, no allocation. Writer serialization stays on the existing RWMutex to keep the compare-then-swap validation intact. Update the StateMachine.State interface docstring to say the returned proto is immutable.

## Test Plan

### Added a UT bemchmark for parallel reads

```
BenchmarkStateReadParallel on this machine (AMD EPYC 7B13):
  before -cpu=1  : 239   ns/op  96 B/op  2 allocs/op
  before -cpu=16 :  ~102 ns/op  96 B/op  2 allocs/op
  after  -cpu=1  :   0.58 ns/op  0 B/op  0 allocs/op
  after  -cpu=16 :   0.07 ns/op  0 B/op  0 allocs/op
```

### Manual testing on a 4-node CCES cluster
1. Update kronos version with this commit and build `cockroach`
2. Copy the binary to a CCES node and replace `/usr/local/bin/cockroach`
3. Restart cockroachdb on two nodes: (i) one with the changes, (ii) one without.
5. Capture heap profile on both nodes after 45 mins using `curl -sk https://localhost:26258/debug/pprof/heap` so that we can compare allocations made in the same time period before and after the change.
6. Compare both profiles, notice `reflect.New` line is gone in the new profile vs old. So, there are **36 million** fewer objects created in the new profile due to this change.

Old profile: https://phabricator.rubrik.com/P33297
<img width="1351" height="756" alt="image" src="https://github.com/user-attachments/assets/583b89a9-0303-40ac-95cd-d67abb8923dc" />

New profile: https://phabricator.rubrik.com/P33296
<img width="1346" height="728" alt="image" src="https://github.com/user-attachments/assets/260bdc49-b123-46d4-830f-4009bbad6f61" />

