### PR TITLE
Extract KronosTime/UptimeNowRaw to skip response proto on local hot path

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -152,19 +152,19 @@ func (k *Server) OracleTime(
 		)
 	}
 
-	kt, err := k.KronosTimeNow(ctx)
+	t, _, err := k.KronosTimeNowRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	ut, err := k.KronosUptimeNow(ctx)
+	u, _, err := k.KronosUptimeNowRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return &kronospb.OracleTimeResponse{
-		Time:   kt.Time,
-		Uptime: ut.Uptime,
+		Time:   t,
+		Uptime: u,
 	}, nil
 }
 
@@ -183,9 +183,24 @@ func (k *Server) KronosUptimeNow(
 	return k.KronosUptime(ctx, &kronospb.KronosUptimeRequest{})
 }
 
+// KronosUptime implements the gRPC KronosUptime method. Local callers should
+// prefer KronosUptimeNowRaw to avoid allocating the response proto.
 func (k *Server) KronosUptime(
 	ctx context.Context, request *kronospb.KronosUptimeRequest,
 ) (*kronospb.KronosUptimeResponse, error) {
+	u, uCap, err := k.KronosUptimeNowRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &kronospb.KronosUptimeResponse{Uptime: u, UptimeCap: uCap}, nil
+}
+
+// KronosUptimeNowRaw returns the current KronosUptime and the current
+// uptime cap as scalar values. It is the allocation-free variant used by
+// the CockroachDB HLC hot path (and by any local caller that does not
+// need the KronosUptimeResponse proto). KronosUptime is a thin wrapper
+// that builds the response for the gRPC entry point.
+func (k *Server) KronosUptimeNowRaw(ctx context.Context) (uptime int64, uptimeCap int64, err error) {
 	oracleData := k.OracleSM.State(ctx)
 
 	k.mu.Lock()
@@ -208,7 +223,7 @@ func (k *Server) KronosUptime(
 		errorMsg = "kronos up time is beyond current time cap, time cap is too stale"
 	}
 	if errorMsg != "" {
-		return nil, errors.Errorf(
+		return 0, 0, errors.Errorf(
 			"%s: kronos uptime: %v, status: %v, uptime time cap: %v",
 			errorMsg, t, currentStatus, oracleData.KronosUptimeCap,
 		)
@@ -220,13 +235,26 @@ func (k *Server) KronosUptime(
 	}
 
 	k.mu.lastKronosUptime = t
-	return &kronospb.KronosUptimeResponse{Uptime: t, UptimeCap: oracleData.KronosUptimeCap}, nil
+	return t, oracleData.KronosUptimeCap, nil
 }
 
 // KronosTimeNow returns the current KronosTime according to the server.
 // If an error is returned, then server might be unitialized or it might have
-// stale data.
+// stale data. Local callers should prefer KronosTimeNowRaw to avoid
+// allocating the response proto.
 func (k *Server) KronosTimeNow(ctx context.Context) (*kronospb.KronosTimeResponse, error) {
+	t, tCap, err := k.KronosTimeNowRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &kronospb.KronosTimeResponse{Time: t, TimeCap: tCap}, nil
+}
+
+// KronosTimeNowRaw returns the current KronosTime and the current time cap
+// as scalar values. It is the allocation-free variant used by the
+// CockroachDB HLC hot path (CDM-552295). KronosTimeNow is a thin wrapper
+// that builds the response proto for the gRPC entry point.
+func (k *Server) KronosTimeNowRaw(ctx context.Context) (time int64, timeCap int64, err error) {
 	oracleData := k.OracleSM.State(ctx)
 
 	k.mu.Lock()
@@ -253,7 +281,7 @@ func (k *Server) KronosTimeNow(ctx context.Context) (*kronospb.KronosTimeRespons
 		errorMsg = "kronos time is beyond current time cap, time cap is too stale"
 	}
 	if errorMsg != "" {
-		return nil, errors.Errorf(
+		return 0, 0, errors.Errorf(
 			"%s: kronos time: %v, status: %v, time cap: %v",
 			errorMsg, t, currentStatus, oracleData.TimeCap,
 		)
@@ -265,7 +293,7 @@ func (k *Server) KronosTimeNow(ctx context.Context) (*kronospb.KronosTimeRespons
 	}
 
 	k.mu.lastKronosTime = t
-	return &kronospb.KronosTimeResponse{Time: t, TimeCap: oracleData.TimeCap}, nil
+	return t, oracleData.TimeCap, nil
 }
 
 func (k *Server) shouldOverthrowOracle(ctx context.Context) bool {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -686,6 +686,80 @@ func TestNodeAddrEqual(t *testing.T) {
 	}
 }
 
+// newBenchServer builds a Server wired up for the KronosTimeNow /
+// KronosUptime happy path: initialized status, valid time cap, valid uptime
+// cap, self as oracle. Used by BenchmarkKronosTimeNow* to measure the hot
+// path CockroachDB HLC reads travel through.
+func newBenchServer(b *testing.B) *Server {
+	b.Helper()
+	clock := tm.NewManualClock()
+	clock.SetTime(100)
+	clock.SetUptime(100)
+	local := &kronospb.NodeAddr{Host: "127.0.0.1", Port: "5766"}
+	sm := oracle.NewMemStateMachine()
+	sm.SubmitProposal(context.Background(), &kronospb.OracleProposal{
+		ProposedState: &kronospb.OracleState{
+			Id:              1,
+			TimeCap:         int64(time.Hour),
+			KronosUptimeCap: int64(time.Hour),
+			Oracle:          local,
+		},
+	})
+	s := &Server{
+		Clock:    clock,
+		OracleSM: sm,
+		GRPCAddr: local,
+	}
+	s.status.Store(kronospb.ServerStatus_INITIALIZED)
+	return s
+}
+
+// BenchmarkKronosTimeNow documents the CDM-552295 hot path: every
+// CockroachDB HLC clock read reaches this function via kronos.GetTime.
+// The proto variant allocates one KronosTimeResponse per call; the raw
+// variant returns primitives and reports 0 allocs/op.
+func BenchmarkKronosTimeNow(b *testing.B) {
+	ctx := context.Background()
+	s := newBenchServer(b)
+	b.Run("proto", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_, _ = s.KronosTimeNow(ctx)
+			}
+		})
+	})
+	b.Run("raw", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_, _, _ = s.KronosTimeNowRaw(ctx)
+			}
+		})
+	})
+}
+
+func BenchmarkKronosUptime(b *testing.B) {
+	ctx := context.Background()
+	s := newBenchServer(b)
+	b.Run("proto", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_, _ = s.KronosUptimeNow(ctx)
+			}
+		})
+	})
+	b.Run("raw", func(b *testing.B) {
+		b.ReportAllocs()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_, _, _ = s.KronosUptimeNowRaw(ctx)
+			}
+		})
+	})
+}
+
 // BenchmarkNodeAddrEqual documents the alloc/CPU savings for CDM-552295: the
 // hand-written comparison runs at reflection-free speed and reports 0
 // allocs/op, whereas gogo/proto.Equal — used by every isOracle call on the

--- a/time.go
+++ b/time.go
@@ -67,7 +67,7 @@ func Now() int64 {
 	var count = 0
 
 	for {
-		kt, err := kronosServer.KronosTimeNow(ctx)
+		t, _, err := kronosServer.KronosTimeNowRaw(ctx)
 		if err != nil {
 			// We print the first 10 retries, then every 10th retry until 200 retries, and then every 100th retry
 			if count < 10 || (count < 200 && count%10 == 0) || count%100 == 0 {
@@ -81,7 +81,7 @@ func Now() int64 {
 			count += 1
 			continue
 		}
-		return kt.Time
+		return t
 	}
 }
 
@@ -98,12 +98,12 @@ func Uptime() int64 {
 	ctx := context.TODO()
 
 	for {
-		ut, err := kronosServer.KronosUptimeNow(ctx)
+		u, _, err := kronosServer.KronosUptimeNowRaw(ctx)
 		if err != nil {
 			time.Sleep(timePollInterval)
 			continue
 		}
-		return ut.Uptime
+		return u
 	}
 }
 
@@ -162,7 +162,7 @@ func GetTime(timeout time.Duration) (int64, error) {
 	var count = 0
 	start := time.Now()
 	for timeout == 0 || time.Since(start) < timeout {
-		kt, err := kronosServer.KronosTimeNow(ctx)
+		t, _, err := kronosServer.KronosTimeNowRaw(ctx)
 		if err != nil {
 			// We print the first 10 retries, then every 10th retry until 200 retries, and then every 100th retry
 			if count < 10 || (count < 200 && count%10 == 0) || count%100 == 0 {
@@ -176,7 +176,7 @@ func GetTime(timeout time.Duration) (int64, error) {
 			count += 1
 			continue
 		}
-		return kt.Time, nil
+		return t, nil
 	}
 	return 0, errors.New(fmt.Sprintf(
 		"Couldn't get kronos time within timeout - %v", timeout))


### PR DESCRIPTION
## Summary

CockroachDB reaches KronosTimeNow through kronos.GetTime for every HLC clock read. The response — a *kronospb.KronosTimeResponse — is a fresh heap allocation on every call, yet every hot-path consumer reads only the Time field and discards the rest. Same story for KronosUptime via kronos.Uptime.

Extract the actual implementation into two exported primitives:
  Server.KronosTimeNowRaw(ctx)   (time, timeCap int64, err error)
  Server.KronosUptimeNowRaw(ctx) (uptime, uptimeCap int64, err error)

KronosTimeNow and KronosUptime become 3-line wrappers that build the response proto — kept because the gRPC service interface still needs them. Route the local hot callers to Raw:
  kronos.Now(), kronos.GetTime()  → KronosTimeNowRaw
  kronos.Uptime()                 → KronosUptimeNowRaw
  Server.OracleTime               → both Raw variants (also drops the two
                                    intermediate proto allocations)

Mock code paths (mock_client.go, mock_cluster.go) continue to use the proto wrappers; they are not on the hot path and mock_client sets Rtt on the response.

BenchmarkKronosTimeNow on this machine (AMD EPYC 7B13):
  proto -cpu=1  :  43 ns/op  32 B/op  1 allocs/op
  proto -cpu=16 : 129 ns/op  32 B/op  1 allocs/op
  raw   -cpu=1  :  19 ns/op   0 B/op  0 allocs/op
  raw   -cpu=16 :  80 ns/op   0 B/op  0 allocs/op
KronosUptime shows the same shape. The remaining -cpu=16 gap is
k.mu.Lock contention — that is the deferred lock-free follow-up.

## Test Plan
Please refer Phase 2 (macrobenchmark) runs in doc:
https://docs.google.com/document/d/182rpwhAFy4jVhrM1pdSUakbOS4L8FTZCd4lZU6qsvPw/edit?tab=t.0